### PR TITLE
Remove forced parenthesis colours

### DIFF
--- a/OneDarkPro.rstheme
+++ b/OneDarkPro.rstheme
@@ -854,10 +854,6 @@ span .GFUP41PBN-B.ace_constant.ace_language {
     color: #51b6c3;
 }
 
-.ace_paren {
-  color: #abb2bf !important;
-}
-
 .ace_keyword.ace_other.ace_unit {
   color: #d19a66;
 }


### PR DESCRIPTION
Thought I'd suggest this, since I made this edit in my version.

By not having a set paren colour, the 'rainbow parenthesis' option in RStudio is able to work. If you choose to leave it off, the colour is still correct.